### PR TITLE
Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "12"


### PR DESCRIPTION
Add travis.yml

Run CI at version `12` because `find . -name package.json | xargs grep -h node\": | sort | uniq -c` shows the min node.js version is 12

Travis still need authorization to our organization before Travis start to work